### PR TITLE
Past Poisoning Attack Implemented on CIFAR10: Past data labels switch to current task labels

### DIFF
--- a/datasets/seq_cifar10_label_poisoning.py
+++ b/datasets/seq_cifar10_label_poisoning.py
@@ -72,6 +72,22 @@ class TrainCIFAR10(MammothDataset, CIFAR10):
                 possible_labels = [cls for cls in classes if cls != original_label]
                 self.targets[i] = np.random.choice(possible_labels)
 
+    def apply_past_label_flip_poisoning(self, poisoned_classes: list, current_classes: list):
+        if len(set(self.classes).union(poisoned_classes)) == 0:
+            return
+        self.poisoned_classes.extend(poisoned_classes)
+
+        if len(poisoned_classes) < 2: 
+            raise ValueError('At least 2 poisoned classes required to randomly switch labels between them')
+
+        switch_prob = [0.0, 0.25, 0.5, 0.75, 1.0][self.poisoning_severity - 1]
+
+        for i in range(len(self.targets)):
+            original_label = self.targets[i]
+            if original_label in poisoned_classes and np.random.rand() < switch_prob:
+                possible_labels = [cls for cls in current_classes]
+                self.targets[i] = np.random.choice(possible_labels)
+
     def prepare_normal_data(self):
         pass
 

--- a/datasets/utils/continual_dataset.py
+++ b/datasets/utils/continual_dataset.py
@@ -9,7 +9,9 @@ from typing import Tuple
 import numpy as np
 import torch.nn as nn
 import torch.optim
+import torch.utils
 from torch.utils.data import DataLoader
+import torch.utils.data
 from datasets.stream_spec import StreamSpecification
 from datasets.mammoth_dataset import MammothDataset
 
@@ -40,7 +42,7 @@ class ContinualDataset:
                 "The dataset must be initialized with all the required fields."
             )
 
-        if args.n_poisonings:
+        if args.n_poisonings or args.n_past_poisonings:
             n_tasks = self.N_TASKS
             n_classes = self.N_CLASSES_PER_TASK * self.N_TASKS
             self.stream_spec = StreamSpecification(
@@ -48,6 +50,7 @@ class ContinualDataset:
                 n_classes,
                 random_seed=args.seed,
                 n_poisonings=args.n_poisonings,
+                n_past_poisonings=args.n_past_poisonings,
                 classes_per_poisoning=args.classes_per_poisoning,
             )
             self.stream_spec_it = iter(self.stream_spec)
@@ -81,6 +84,9 @@ class ContinualDataset:
         print(f"Poisoned Classes: {poisoned_classes}")
 
         train_dataset = None
+        test_dataset = self.get_dataset(train=False)
+        test_dataset.select_classes(current_classes + poisoned_classes)
+
         if len(current_classes) > 0:
             train_dataset = self.get_dataset(train=True)
             train_dataset.select_classes(current_classes)
@@ -88,7 +94,33 @@ class ContinualDataset:
         if len(poisoned_classes) > 0:
             poisoned_train_dataset = self.get_dataset(train=True)
             poisoned_train_dataset.select_classes(poisoned_classes)
-            poisoned_train_dataset.apply_poisoning(poisoned_classes)
+
+            assert (
+                self.args.n_poisonings is not None
+                or self.args.n_past_poisonings is not None
+            ), "Must specify poisoning mechanism: n_poisonings or n_past_poisonings \n \
+                n_poisonings: For poisoning n-th task(s) with image or label flip poisoning \n \
+                n_past_poisonings: For poisoning n-th task(s) with label flip poisoning from previous tasks"
+
+            if self.args.n_poisonings is not None:
+                poisoned_train_dataset.apply_poisoning(poisoned_classes)                
+            elif self.args.n_past_poisonings is not None:
+                assert self.args.poisoning_percentage is not None, "Must specify percentage of poisoned data (0 ~ 100)"
+                assert len(train_dataset) > 0, "Need new classes in training data for past label flip poisoning"
+
+                poisoned_train_dataset.apply_past_label_flip_poisoning(poisoned_classes, current_classes)
+
+                total_samples = len(train_dataset)
+                num_poisoned_samples = int(total_samples * (self.args.poisoning_percentage / 100))
+                num_regular_samples = total_samples - num_poisoned_samples
+
+                num_poisoned_samples = min(len(poisoned_train_dataset), num_poisoned_samples)
+                num_regular_samples = min(len(train_dataset), num_regular_samples)
+                poisoned_train_dataset = torch.utils.data.Subset(poisoned_train_dataset, range(num_poisoned_samples))
+                train_dataset = torch.utils.data.Subset(train_dataset, range(num_regular_samples))
+
+                test_dataset = self.get_dataset(train=False)
+                test_dataset.select_classes(current_classes)
 
             if train_dataset is not None:
                 train_dataset = torch.utils.data.ConcatDataset([train_dataset, poisoned_train_dataset])
@@ -101,8 +133,6 @@ class ContinualDataset:
         train_loader = DataLoader(train_dataset, batch_size=self.args.batch_size, shuffle=True, num_workers=4)
         self.train_loader = train_loader
 
-        test_dataset = self.get_dataset(train=False)
-        test_dataset.select_classes(current_classes + poisoned_classes)
         test_loader = DataLoader(test_dataset, batch_size=self.args.batch_size, shuffle=False, num_workers=4)
         self.test_loaders.append(test_loader)
 

--- a/utils/args.py
+++ b/utils/args.py
@@ -44,7 +44,11 @@ def add_experiment_args(parser: ArgumentParser) -> None:
     parser.add_argument('--poisoning_severity', default=1, choices=[1, 2, 3, 4, 5], type=int,
                         help='Choose the intensity of the poisoning transform:')
     parser.add_argument('--n_poisonings', default=None, type=int,
-                        help='number of poisonings created when creating evenly spaced drfits')
+                        help='number of poisonings created when creating evenly spaced poisonings')
+    parser.add_argument('--n_past_poisonings', default=None, type=int,
+                        help='number of past label poisonings created when creating evenly spaced poisonings')
+    parser.add_argument('--poisoning_percentage', default=None, choices=list(range(101)), type=int, 
+                        help='Choose the percentage (0 ~ 100) of poisoned samples to be included in training batch')
     parser.add_argument('--classes_per_poisoning', type=int, default=0,
                         help='Number of classes that can be poisoned at once with n_poisonings. \
                         If set to 0 (default), all previous classes will be poisoned.')

--- a/utils/training.py
+++ b/utils/training.py
@@ -36,6 +36,13 @@ def mask_classes(outputs: torch.Tensor, dataset: ContinualDataset, k: int) -> No
     outputs[:, (k + 1) * dataset.N_CLASSES_PER_TASK:
             dataset.N_TASKS * dataset.N_CLASSES_PER_TASK] = -float('inf')
 
+def get_unique_labels(test_loader):
+    labels = []
+    for _, batch_labels in test_loader:
+        labels.extend(batch_labels.numpy())
+
+    unique_labels = torch.unique(torch.tensor(labels))
+    return unique_labels.tolist()
 
 def evaluate(model: ContinualModel, dataset: ContinualDataset, last=False) -> Tuple[list, list]:
     """
@@ -54,6 +61,9 @@ def evaluate(model: ContinualModel, dataset: ContinualDataset, last=False) -> Tu
         correct, correct_mask_classes, total = 0.0, 0.0, 0.0
         predictions = list()
         all_labels = list()
+
+        # unique_labels = get_unique_labels(test_loader)
+        # print("Unique labels in the test loader:", unique_labels)
 
         for data in test_loader:
             with torch.no_grad():


### PR DESCRIPTION
Past label switch attack implemented on CIFAR10. `n_past_poisonings` and `poisoning_percentage` arguments are used for this. Based on the percentage value, the past tasks are combined with the current train loader to keep the data loader the same size as the current task. The data-loader pipeline still contains the previously implemented image poisoning attacks and current task label interchanging attacks for future experiments.